### PR TITLE
Fixed problem with scaling 

### DIFF
--- a/RNInputManager.lua
+++ b/RNInputManager.lua
@@ -305,6 +305,8 @@ end
 function onEvent(eventType, idx, x, y, tapCount)
 
     local screen = RNFactory.getCurrentScreen()
+    
+    local x , y = RNFactory.screen.layer:wndToWorld(x, y)
 
     local currenTarget = screen:getRNObjectWithHighestLevelOn(x, y);
     local event = RNEvent:new()


### PR DESCRIPTION
When you set a different scale than size (in RNScreen:initWith method), after, if you try to access to any Prop for example with a touch event , this fail.

This is solved adding "local x , y = RNFactory.screen.layer:wndToWorld(x, y)" in line 308 of RNInputManager.lua -> method onEvent.

Example:

```
function onEvent(eventType, idx, x, y, tapCount)

local screen = RNFactory.getCurrentScreen()

local x , y = RNFactory.screen.layer:wndToWorld(x, y)

local currenTarget = screen:getRNObjectWithHighestLevelOn(x, y);

local event = RNEvent:new()

event:initWithEventType(eventType)

event.x = x

event.y = y

...
```
