### PR TITLE
RNObject:remove patches

### DIFF
--- a/rapanui-sdk/RNObject.lua
+++ b/rapanui-sdk/RNObject.lua
@@ -1173,7 +1173,9 @@ function RNObject:remove()
         self.prop:setDeck(nil)
     end
     --print("remove", self.idInGroup)
-    self.parentGroup:removeChild(self.idInGroup)
+	if(self.parentGroup) then
+    	self.parentGroup:removeChild(self.idInGroup)
+	end
 end
 
 --if it's awake (returns boolean)

--- a/rapanui-sdk/RNScreen.lua
+++ b/rapanui-sdk/RNScreen.lua
@@ -90,13 +90,12 @@ function RNScreen:removeRNObject(object)
             for k = ind + 1, len, 1 do
                 self.sprites[k - 1] = self.sprites[k]
                 self.sprites[k].idInScreen = k - 1
+				self.sprites[k]:getProp().rnObjectId = k - 1
             end
             self.sprites[len] = nil
         end
     end
 
-    --refresh other objects id
-    for i, v in ipairs(self.sprites) do v.idInScreen = i end
     --
     self.numSprites = table.getn(self.sprites)
 end


### PR DESCRIPTION
Hi there,

I came across two problems with RNObject:remove recently when working with rectangles.  I'm submitting them as a single pull request.  The problems are outlined below.
# RNObject:remove throws exception when parentGroup is nil

Specifically, several rectangles were created with RNFactory.createRect().  The create function seemed careful not to set the parentGroup field.  However, the remove function does not check for this condition, assumes parentGroup is always valid, and calls a function on parentGroup, which is nil.
# RNScreen:removeRNObject doesn't update MOAI prop -> RNObject mapping

It looks like rapanui relies on the RNScreen.sprites table to maintain a MOAI prop -> RNObject mapping.  It's then used to process touch input, using MOAI for object picking, then using the sprites table to retrieve the corresponding RNObject.

On object removal, removeRNObject function does properly update the objects' index to itself in the sprites table.  But, it doesn't update the MOAI prop's index to their corresponding RNObject in the sprites table.

The end result is... as soon as an object is removed, object picking cease to function correctly.  Touching one object would cause the touch handler on a "random" object to be fired instead.
