### PR TITLE
Generalize RNFactory.createButton to accept RNObjects in place of image paths

### DIFF
--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -298,7 +298,7 @@ function RNFactory.createButton(image, params)
         yOffset = params.yOffset
     end
 
-    function initButtonImage( image )
+    local function initButtonImage( image )
         local rnObj, deck
         if type(image) == "string" then
             rnObj = RNObject:new()

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -299,20 +299,20 @@ function RNFactory.createButton(image, params)
     end
 
     function initButtonImage( image )
-       local rnObj, deck
-       if type(image) == "string" then
-          rnObj = RNObject:new()
-          rnObj, deck = rnObj:initWithImage2( image )
-       else
-          -- assume image is already an RNObject
-          rnObj = image
-       end
+        local rnObj, deck
+        if type(image) == "string" then
+            rnObj = RNObject:new()
+            rnObj, deck = rnObj:initWithImage2( image )
+        else
+            -- assume image is already an RNObject
+            rnObj = image
+        end
 
-       rnObj.x = rnObj.originalWidth / 2 + left
-       rnObj.y = rnObj.originalHeight / 2 + top
-       RNFactory.screen:addRNObject( rnObj )
+        rnObj.x = rnObj.originalWidth / 2 + left
+        rnObj.y = rnObj.originalHeight / 2 + top
+        RNFactory.screen:addRNObject( rnObj )
 
-       return rnObj, deck
+        return rnObj, deck
     end
 
     -- init of default RNButtonImage

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -299,13 +299,19 @@ function RNFactory.createButton(image, params)
     end
 
     function initButtonImage( image )
-       local rnObj = RNObject:new()
-       local rnObj, deck = rnObj:initWithImage2( image )
+       local rnObj, deck
+       if type(image) == "string" then
+          rnObj = RNObject:new()
+          rnObj, deck = rnObj:initWithImage2( image )
+       else
+          -- assume image is already an RNObject
+          rnObj = image
+       end
 
        rnObj.x = rnObj.originalWidth / 2 + left
        rnObj.y = rnObj.originalHeight / 2 + top
-
        RNFactory.screen:addRNObject( rnObj )
+
        return rnObj, deck
     end
 

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -298,45 +298,31 @@ function RNFactory.createButton(image, params)
         yOffset = params.yOffset
     end
 
-    -- init of default RNButtonImage
-    local rnButtonImage = RNObject:new()
-    local rnButtonImage, deck = rnButtonImage:initWithImage2(image)
+    function initButtonImage( image )
+       local rnObj = RNObject:new()
+       local rnObj, deck = rnObj:initWithImage2( image )
 
-    rnButtonImage.x = rnButtonImage.originalWidth / 2 + left
-    rnButtonImage.y = rnButtonImage.originalHeight / 2 + top
+       rnObj.x = rnObj.originalWidth / 2 + left
+       rnObj.y = rnObj.originalHeight / 2 + top
 
-    RNFactory.screen:addRNObject(rnButtonImage)
-
-
-    local rnButtonImageOver
-
-    if params.imageOver ~= nil then
-
-        rnButtonImageOver = RNObject:new()
-        rnButtonImageOver, deck = rnButtonImageOver:initWithImage2(params.imageOver)
-
-        rnButtonImageOver.x = rnButtonImageOver.originalWidth / 2 + left
-        rnButtonImageOver.y = rnButtonImageOver.originalHeight / 2 + top
-
-        rnButtonImageOver:setVisible(false)
-
-        RNFactory.screen:addRNObject(rnButtonImageOver)
+       RNFactory.screen:addRNObject( rnObj )
+       return rnObj, deck
     end
 
+    -- init of default RNButtonImage
+    local rnButtonImage
+    rnButtonImage, deck = initButtonImage( image )
+
+    local rnButtonImageOver
+    if params.imageOver ~= nil then
+        rnButtonImageOver, deck = initButtonImage( params.imageOver )
+        rnButtonImageOver:setVisible( false )
+    end
 
     local rnButtonImageDisabled
-
     if params.imageDisabled ~= nil then
-
-        rnButtonImageDisabled = RNObject:new()
-        rnButtonImageDisabled, deck = rnButtonImageDisabled:initWithImage2(params.imageDisabled)
-
-        rnButtonImageDisabled.x = rnButtonImageDisabled.originalWidth / 2 + left
-        rnButtonImageDisabled.y = rnButtonImageDisabled.originalHeight / 2 + top
-
+        rnButtonImageDisabled, deck = initButtonImage( params.imageDisabled )
         rnButtonImageDisabled:setVisible(false)
-
-        RNFactory.screen:addRNObject(rnButtonImageDisabled)
     end
 
     local rnText

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -316,8 +316,7 @@ function RNFactory.createButton(image, params)
     end
 
     -- init of default RNButtonImage
-    local rnButtonImage
-    rnButtonImage, deck = initButtonImage( image )
+    local rnButtonImage, deck = initButtonImage( image )
 
     local rnButtonImageOver
     if params.imageOver ~= nil then

--- a/rapanui-sdk/RNObject.lua
+++ b/rapanui-sdk/RNObject.lua
@@ -394,6 +394,8 @@ function RNObject:initCopyRect(src, params)
 
     self.alpha = 1
     self:loadCopyRect(src, params)
+
+    return self
 end
 
 
@@ -425,6 +427,8 @@ function RNObject:initBlank(width, height)
     self.prop:setDeck(self.gfxQuad)
     self.gfxQuad:setRect(-self.originalWidth / 2, -self.originalHeight / 2, (self.originalWidth) / 2, (self.originalHeight) / 2)
     self.prop:setPriority(1)
+
+    return self
 end
 
 function RNObject:loadCopyRect(src, params)
@@ -471,6 +475,8 @@ function RNObject:loadCopyRect(src, params)
     self.prop:setDeck(self.gfxQuad)
     self.gfxQuad:setRect(-self.originalWidth / 2, -self.originalHeight / 2, (self.originalWidth) / 2, (self.originalHeight) / 2)
     self.prop:setPriority(1)
+
+    return self
 end
 
 
@@ -505,6 +511,8 @@ function RNObject:initWithMoaiImage(moaiImage)
     self.prop:setDeck(self.gfxQuad)
     self.gfxQuad:setRect(-self.originalWidth / 2, -self.originalHeight / 2, (self.originalWidth) / 2, (self.originalHeight) / 2)
     self.prop:setPriority(1)
+
+    return self
 end
 
 
@@ -621,6 +629,8 @@ function RNObject:initWithRect(width, height, rgb)
     self.childrenSize = 0
     self.alpha = 1
     self:loadRect(width, height, rgb)
+
+    return self
 end
 
 
@@ -629,6 +639,8 @@ function RNObject:initWithCircle(x, y, r, rgb)
     self.childrenSize = 0
     self.alpha = 1
     self:loadCircle(x, y, r, rgb)
+
+    return self
 end
 
 
@@ -656,6 +668,8 @@ function RNObject:loadRect(width, height, rgb)
     self.prop:setDeck(self.gfxQuad)
 
     self.prop:setPriority(1)
+
+    return self
 end
 
 function RNObject:setPenColor(r, g, b, alpha)


### PR DESCRIPTION
While prototyping, it is nice not to have to actually go off and create image files of the desired dimensions for each button. This changeset modifies RNFactory.createButton to check whether provided images are strings. If so, the old behavior is preserved and the string is assumed to be a path to an image file to use. 

Otherwise, it is assumed to be an RNObject. This allows the programmer to procedurally create the button image.

In a semi-related change, I also changed the RNObject:init\* functions to return self, for convenience, and to be consistent with initWithImage2.

So now a quick and dirty button can be created like so:

``` lua
local button = RNFactory.createButton( RNObject:new():initWithRect( 100, 100, { 100, 100, 100}), {
  text = 'foo',
  ...
}
```
