### PR TITLE
Fixed wrong cases in asset paths: RapaNui-samples -> rapanui-samples

### DIFF
--- a/rapanui-samples/games/AngryDogsAgainstMoais/AngryDogsAgainstMoais.lua
+++ b/rapanui-samples/games/AngryDogsAgainstMoais/AngryDogsAgainstMoais.lua
@@ -30,8 +30,8 @@ gameGroup.x = 0; gameGroup.y = 0;
 
 
 --create images
-background = RNFactory.createImage("RapaNui-samples/games/AngryDogsAgainstMoais/grass.png")
-bounding = RNFactory.createImage("RapaNui-samples/games/AngryDogsAgainstMoais/grass.png"); bounding.x = 0; bounding.y = 0;
+background = RNFactory.createImage("rapanui-samples/games/AngryDogsAgainstMoais/grass.png")
+bounding = RNFactory.createImage("rapanui-samples/games/AngryDogsAgainstMoais/grass.png"); bounding.x = 0; bounding.y = 0;
 gameGroup:insert(background)
 gameGroup:insert(bounding)
 
@@ -60,13 +60,13 @@ end
 
 function create_level()
     --creating dog
-    dog = RNFactory.createImage("RapaNui-samples/games/AngryDogsAgainstMoais/dog.png"); dog.x = 100; dog.y = 400;
+    dog = RNFactory.createImage("rapanui-samples/games/AngryDogsAgainstMoais/dog.png"); dog.x = 100; dog.y = 400;
     RNPhysics.createBodyFromImage(dog, { shape = "circle", restitution = 0.4 })
     gameGroup:insert(dog)
     dog.name = "dog"
     lastx = dog.x
     --starting obstacle
-    local obstacle = RNFactory.createImage("RapaNui-samples/games/AngryDogsAgainstMoais/obstacle.png");
+    local obstacle = RNFactory.createImage("rapanui-samples/games/AngryDogsAgainstMoais/obstacle.png");
     obstacle.x = 100; obstacle.y = 500; obstacle.rotation = 90
     RNPhysics.createBodyFromImage(obstacle, "static")
     gameGroup:insert(obstacle)
@@ -74,14 +74,14 @@ function create_level()
     --creating obstacles
     for j = 1, 3, 1 do
         for i = 1, 3, 1 do
-            local obstacle = RNFactory.createImage("RapaNui-samples/games/AngryDogsAgainstMoais/obstacle.png");
+            local obstacle = RNFactory.createImage("rapanui-samples/games/AngryDogsAgainstMoais/obstacle.png");
             obstacle.x = 1000 + i * 100; obstacle.y = 500 - j * 130; obstacle.rotation = 90
             RNPhysics.createBodyFromImage(obstacle, { density = 1 })
             gameGroup:insert(obstacle)
             obstacle.name = "obstacle"
         end
         for i = 1, 2, 1 do
-            local obstacle = RNFactory.createImage("RapaNui-samples/games/AngryDogsAgainstMoais/obstacle.png");
+            local obstacle = RNFactory.createImage("rapanui-samples/games/AngryDogsAgainstMoais/obstacle.png");
             obstacle.x = 1050 + i * 100; obstacle.y = 440 - j * 130; obstacle.rotation = 0
             RNPhysics.createBodyFromImage(obstacle, { density = 1 })
             gameGroup:insert(obstacle)
@@ -91,7 +91,7 @@ function create_level()
     --creating moais
     for j = 1, 3, 1 do
         for i = 1, 2, 1 do
-            local moais = RNFactory.createAnim("RapaNui-samples/games/AngryDogsAgainstMoais/moaianim.png", 64, 64, 0, 0, 1, 1);
+            local moais = RNFactory.createAnim("rapanui-samples/games/AngryDogsAgainstMoais/moaianim.png", 64, 64, 0, 0, 1, 1);
             moais.x = 1050 + i * 100; moais.y = 500 - j * 130; moais.rotation = 0
             RNPhysics.createBodyFromImage(moais, { shape = { -18, -30, 18, -30, 18, 30, -18, 30 }, restitution = 0.4, density = 0.1 })
             gameGroup:insert(moais)
@@ -108,7 +108,7 @@ function create_level()
     lev = RNFactory.createText("0", { size = 20, top = 440, left = 200, width = 30, height = 50 })
 
     --create restart button
-    button = RNFactory.createImage("RapaNui-samples/games/AngryDogsAgainstMoais/restButt.png"); button.x = 160;
+    button = RNFactory.createImage("rapanui-samples/games/AngryDogsAgainstMoais/restButt.png"); button.x = 160;
 end
 
 

--- a/rapanui-samples/games/SunGolf/SunGolf.lua
+++ b/rapanui-samples/games/SunGolf/SunGolf.lua
@@ -24,8 +24,8 @@ shots = 0
 level = 0
 
 --add images
-background = RNFactory.createImage("RapaNui-samples/games/SunGolf/grass.png")
-bounding = RNFactory.createImage("RapaNui-samples/games/SunGolf/grass.png"); bounding.x = 0; bounding.y = 0;
+background = RNFactory.createImage("rapanui-samples/games/SunGolf/grass.png")
+bounding = RNFactory.createImage("rapanui-samples/games/SunGolf/grass.png"); bounding.x = 0; bounding.y = 0;
 
 
 --create a complex body for bounding handling (and set it as invisible)
@@ -45,14 +45,14 @@ function create_level()
     lev:setText("" .. level)
     canChangeLevel = true
     --create images
-    hole = RNFactory.createImage("RapaNui-samples/games/SunGolf/hole.png");
+    hole = RNFactory.createImage("rapanui-samples/games/SunGolf/hole.png");
     hole.x = math.random() * 120 + 100; hole.y = 100
-    ball = RNFactory.createImage("RapaNui-samples/games/SunGolf/gball.png"); ball.x = 240; ball.y = 400;
-    obstacle1 = RNFactory.createImage("RapaNui-samples/games/SunGolf/obstacle.png");
+    ball = RNFactory.createImage("rapanui-samples/games/SunGolf/gball.png"); ball.x = 240; ball.y = 400;
+    obstacle1 = RNFactory.createImage("rapanui-samples/games/SunGolf/obstacle.png");
     obstacle1.x = math.random() * 100 - 20; obstacle1.y = 140 + math.random() * 150; obstacle1.rotation = math.random() * 360;
-    obstacle2 = RNFactory.createImage("RapaNui-samples/games/SunGolf/obstacle.png");
+    obstacle2 = RNFactory.createImage("rapanui-samples/games/SunGolf/obstacle.png");
     obstacle2.x = 160; obstacle2.y = 140 + math.random() * 150; obstacle2.rotation = math.random() * 360;
-    obstacle3 = RNFactory.createImage("RapaNui-samples/games/SunGolf/obstacle.png");
+    obstacle3 = RNFactory.createImage("rapanui-samples/games/SunGolf/obstacle.png");
     obstacle3.x = math.random() * 100 + 280; obstacle3.y = 140 + math.random() * 150; obstacle3.rotation = math.random() * 360;
 
     --add physics bodies

--- a/rapanui-samples/physics/rn-physics-joints.lua
+++ b/rapanui-samples/physics/rn-physics-joints.lua
@@ -85,7 +85,7 @@ j10:remove()
 
 --[[ Mouse Joint Testing
 
-ground=RNFactory.createImage("RapaNui-samples/physics/floor.png");ground.x=0;ground.y=0;
+ground=RNFactory.createImage("rapanui-samples/physics/floor.png");ground.x=0;ground.y=0;
 ground.visible=false
 RNPhysics.createBodyFromImage(ground,"kinematic",{shape={0,0,320,0,320,480,0,480},sensor=true })
 

--- a/rapanui-samples/physics/rn-physics-touchtest.lua
+++ b/rapanui-samples/physics/rn-physics-touchtest.lua
@@ -76,13 +76,13 @@ RNListeners:addEventListener("touch", screen_touch)
 
 function removeBall(self, event)
     --removes the ball if it touches the floor
-    if (event.other.name == "RapaNui-samples/physics/floor.png") then self:remove() end
+    if (event.other.name == "rapanui-samples/physics/floor.png") then self:remove() end
 end
 
 
 function create_ball(xx, yy)
     --each ball calls the remove ball each collision
-    local bb = RNFactory.createImage("RapaNui-samples/physics/ball.png"); bb.x = xx; bb.y = yy;
+    local bb = RNFactory.createImage("rapanui-samples/physics/ball.png"); bb.x = xx; bb.y = yy;
     RNPhysics.createBodyFromImage(bb, { radius = 21, restitution = 0.9, density = 1, friction = 0.3 })
     bb.collision = removeBall
     bb:addEventListener("collision")

--- a/rapanui-samples/physics/test.lua
+++ b/rapanui-samples/physics/test.lua
@@ -180,13 +180,13 @@ RNListeners:addEventListener("touch", screen_touch)
 
 function removeBall(self, event)
     --removes the ball if it touches the floor
-    if (event.other.name == "RapaNui-samples/physics/floor.png") then self:remove() end
+    if (event.other.name == "rapanui-samples/physics/floor.png") then self:remove() end
 end
 
 
 function create_ball(xx, yy)
     --each ball calls the remove ball each collision
-    local bb = RNFactory.createImage("RapaNui-samples/physics/ball.png"); bb.x = xx; bb.y = yy;
+    local bb = RNFactory.createImage("rapanui-samples/physics/ball.png"); bb.x = xx; bb.y = yy;
     RNPhysics.createBodyFromImage(bb, { radius = 21, restitution = 0.9, density = 1, friction = 0.3 })
     bb.collision = removeBall
     bb:addEventListener("collision")


### PR DESCRIPTION
Some of the examples were broken on Linux (and presumably some other platforms) due to asset paths having the wrong cases.
