### PR TITLE
Support 'strict' module

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -12,8 +12,6 @@
 -- Moai (http://getmoai.com/) and RapaNui in the credits of your program.
 --]]
 
-require('strict')
-
 require("rapanui-sdk/rapanui")
 
 --[[ Uncomment to override the default print() function

--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,8 @@
 -- Moai (http://getmoai.com/) and RapaNui in the credits of your program.
 --]]
 
+require('strict')
+
 require("rapanui-sdk/rapanui")
 
 --[[ Uncomment to override the default print() function

--- a/rapanui-samples/games/AngryDogsAgainstMoais/AngryDogsAgainstMoais.lua
+++ b/rapanui-samples/games/AngryDogsAgainstMoais/AngryDogsAgainstMoais.lua
@@ -203,7 +203,7 @@ function Step()
             relocateBall()
         else
             if dog.x - gameGroup.x < 2200 then
-                deltax = dog.x - lastx
+                local deltax = dog.x - lastx
                 gameGroup.x = gameGroup.x - deltax
                 lastx = dog.x
             end
@@ -237,8 +237,8 @@ end
 
 --remove only level objects
 function removeAll()
-    blist = RNPhysics.getBodyList()
-    toRemoveList = {}
+    local blist = RNPhysics.getBodyList()
+    local toRemoveList = {}
     for i = 1, table.getn(blist), 1 do
         print(blist[i].name)
         if (blist[i].name == "moaiObject") or (blist[i].name == "obstacle") or (blist[i].name == "dog") then

--- a/rapanui-samples/games/AngryDogsAgainstMoais/AngryDogsAgainstMoais.lua
+++ b/rapanui-samples/games/AngryDogsAgainstMoais/AngryDogsAgainstMoais.lua
@@ -24,6 +24,13 @@ shots = 0
 startX = 0
 startY = 0
 
+dog = nil
+label = nil
+label2 = nil
+score = nil
+lev = nil
+button = nil
+
 --groups
 gameGroup = RNGroup:new()
 gameGroup.x = 0; gameGroup.y = 0;

--- a/rapanui-samples/games/SunGolf/SunGolf.lua
+++ b/rapanui-samples/games/SunGolf/SunGolf.lua
@@ -23,6 +23,12 @@ canChangeLevel = false
 shots = 0
 level = 0
 
+ball = nil
+hole = nil
+obstacle1 = nil
+obstacle2 = nil
+obstacle3 = nil
+
 --add images
 background = RNFactory.createImage("RapaNui-samples/games/SunGolf/grass.png")
 bounding = RNFactory.createImage("RapaNui-samples/games/SunGolf/grass.png"); bounding.x = 0; bounding.y = 0;

--- a/rapanui-samples/games/brick2d/brick2d.lua
+++ b/rapanui-samples/games/brick2d/brick2d.lua
@@ -34,6 +34,9 @@ bricksBroken = 0
 label = RNFactory.createText("Bricks broken: ", { size = 20, top = 440, left = 5, width = 200, height = 50 })
 score = RNFactory.createText("", { size = 20, top = 440, left = 210, width = 30, height = 50 })
 
+dir = nil
+angle = nil
+
 function init()
     dir = round(math.random() * 1);
     ball.speed = 2;

--- a/rapanui-sdk/RNBody.lua
+++ b/rapanui-sdk/RNBody.lua
@@ -347,7 +347,7 @@ end
 
 --sets all fixture of this body as sensors
 function RNBody:setSensor(value)
-    len = table.getn(self.fixturelist)
+    local len = table.getn(self.fixturelist)
     for i = 1, len, 1 do
         self.fixturelist[i].fixture:setSensor(value)
         self.fixturelist[i].sensor = value

--- a/rapanui-sdk/RNBody.lua
+++ b/rapanui-sdk/RNBody.lua
@@ -243,12 +243,12 @@ end
 -- collision handling
 function RNBody:addEventListener(Type)
     if (Type == "collision") then
-        flist = self.fixturelist
-        len = table.getn(flist)
+        local flist = self.fixturelist
+        local len = table.getn(flist)
         --for each fixture in in self.fixturelist
         for i = 1, len, 1 do
             --sets the fixture for callbacks
-            currentfixture = flist[i].fixture
+            local currentfixture = flist[i].fixture
             currentfixture:setCollisionHandler(RNPhysics.LocalCollisionHandling, RNPhysics.collisionTypeAllowed)
         end
     end

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -20,7 +20,6 @@ contentHeight = nil
 contentWidth = nil
 contentScaleX = nil
 contentScaleY = nil
-contentWidth = nil
 screenOriginX = nil
 screenOriginY = nil
 statusBarHeight = nil

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -135,7 +135,7 @@ function RNFactory.init()
 
 
 
-    RNInputManager.setGlobalRNScreen(screen)
+    RNInputManager.setGlobalRNScreen(RNFactory.screen)
 end
 
 -- extra method call to setup the underlying system

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -60,7 +60,7 @@ function RNFactory.init()
 
     screenX, screenY = nil
 
-
+    local name = rawget(_G, 'name') -- looking for *global* 'name'
     if name == nil then
         name = "mainwindow"
     end

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -73,7 +73,7 @@ function RNFactory.init()
     RNFactory.width = lwidth
     RNFactory.height = lheight
 
-    contentlwidth = lwidth
+    contentWidth = lwidth
     contentHeight = lheight
 
     RNFactory.outWidth = RNFactory.width

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -537,8 +537,7 @@ function RNFactory.createBitmapText(text, params)
          ]]
 
     local charcodes, endsizex, sizey, sizex, left, top, scaleX, scaleY, charWidth, charHeight, image, parentGroup
-
-
+    local hAlignment, vAlignment
 
     if params.image ~= nil then
         image = params.image
@@ -568,6 +567,14 @@ function RNFactory.createBitmapText(text, params)
         parentGroup = params.parentGroup
     else
         parentGroup = RNFactory.mainGroup
+    end
+
+    if params.hAlignment ~= nil then
+        hAlignment = params.hAlignment
+    end
+
+    if params.vAlignment ~= nil then
+        vAlignment = params.vAlignment
     end
 
     local o = RNBitmapText:new()

--- a/rapanui-sdk/RNFactory.lua
+++ b/rapanui-sdk/RNFactory.lua
@@ -58,7 +58,7 @@ function RNFactory.init()
         screenlwidth, screenHeight = screenHeight, screenlwidth
     end
 
-    landscape, device, sizes, screenX, screenY = nil
+    screenX, screenY = nil
 
 
     if name == nil then

--- a/rapanui-sdk/RNFixture.lua
+++ b/rapanui-sdk/RNFixture.lua
@@ -68,7 +68,7 @@ end
 function RNFixture:new(o)
     local fixture = RNFixture:innerNew(o)
     local proxy = setmetatable({}, { __newindex = fieldChangedListener, __index = fieldAccessListener, __object = fixture })
-    return proxy, physicObject
+    return proxy
 end
 
 

--- a/rapanui-sdk/RNInputManager.lua
+++ b/rapanui-sdk/RNInputManager.lua
@@ -40,8 +40,8 @@ function RNInputManager:new(o)
         name = "RNInputManager",
         listeners = {},
         size = 0,
-        pointerX,
-        pointerY
+        pointerX=nil,
+        pointerY=nil,
     }
 
     setmetatable(o, self)

--- a/rapanui-sdk/RNMapLayer.lua
+++ b/rapanui-sdk/RNMapLayer.lua
@@ -309,7 +309,7 @@ function RNMapLayer:createPhysicBodies()
         shape
 
     --]]
-    currentLayer = self
+    local currentLayer = self
     if currentLayer.imagesToBePhysical ~= nil then
         for i = 1, table.getn(currentLayer.imagesToBePhysical), 1 do
             currentTile = currentLayer.imagesToBePhysical[i]

--- a/rapanui-sdk/RNPhysics.lua
+++ b/rapanui-sdk/RNPhysics.lua
@@ -305,7 +305,7 @@ function RNPhysics.createBodyFromImage(image, ...)
 
             --if has been set a listener for collision(so the other fixtures have been set for
             --collision callbacks) also new fixtures should give a callback for collision!
-            if (collisionListenerExists == true) then fixture:setCollisionHandler(RNPhysics.CollisionHandling, RNPhysics.collisionTypeAllowed)
+            if (RNPhysics.collisionListenerExists == true) then fixture:setCollisionHandler(RNPhysics.CollisionHandling, RNPhysics.collisionTypeAllowed)
             end
         end --end arg for
 
@@ -338,7 +338,7 @@ function RNPhysics.createBodyFromImage(image, ...)
 
         --if has been set a listener for collision(so the other fixtures have been set for
         --collision callbacks) also new fixtures should give a callback for collision!
-        if (collisionListenerExists == true) then fixture:setCollisionHandler(RNPhysics.CollisionHandling, RNPhysics.collisionTypeAllowed)
+        if (RNPhysics.collisionListenerExists == true) then fixture:setCollisionHandler(RNPhysics.CollisionHandling, RNPhysics.collisionTypeAllowed)
         end
     end --end if arg>0
 
@@ -548,7 +548,7 @@ function RNPhysics.createBodyFromMapObject(mapObject, ...)
 
         --if has been set a listener for collision(so the other fixtures have been set for
         --collision callbacks) also new fixtures should give a callback for collision!
-        if (collisionListenerExists == true) then fixture:setCollisionHandler(CollisionHandling, RNPhysics.collisionTypeAllowed)
+        if (RNPhysics.collisionListenerExists == true) then fixture:setCollisionHandler(CollisionHandling, RNPhysics.collisionTypeAllowed)
         end
     end --end if arg>0
 

--- a/rapanui-sdk/RNPhysics.lua
+++ b/rapanui-sdk/RNPhysics.lua
@@ -97,7 +97,7 @@ end
 -- @param meters float: meters per box2d units
 function RNPhysics.setMeters(meters)
     RNPhysics.world:setUnitsToMeters(meters / 1000)
-    units = meters
+    RNPhysics.units = meters
 end
 
 --- sets physics iterations (see box2d docs)
@@ -110,7 +110,7 @@ end
 --- gets meters per units
 -- @return units float
 function RNPhysics.getMeters()
-    return units
+    return RNPhysics.units
 end
 
 --- see box2d docs

--- a/rapanui-sdk/RNPhysics.lua
+++ b/rapanui-sdk/RNPhysics.lua
@@ -33,62 +33,62 @@ function RNPhysics.start(value)
     if value ~= nil then
         print("noSleep not available at the moment")
     end
-    world = MOAIBox2DWorld.new()
-    world:setGravity(0, 10)
-    world:start()
-    world:setUnitsToMeters(0.06)
+    RNPhysics.world = MOAIBox2DWorld.new()
+    RNPhysics.world:setGravity(0, 10)
+    RNPhysics.world:start()
+    RNPhysics.world:setUnitsToMeters(0.06)
 end
 
 --- sets the sleeping time of physics objects
 -- @param value number: time to sleep
 function RNPhysics.setTimeToSleep(value)
-    if value ~= nil then world:setTimeToSleep(value) else world:setTimeToSleep()
+    if value ~= nil then RNPhysics.world:setTimeToSleep(value) else RNPhysics.world:setTimeToSleep()
     end
 end
 
 --- sets the linear sleep tolerance
 function RNPhysics.setLinearSleepTolerance()
-    if value ~= nil then world:setLinearSleepTolerance(value) else world:setLinearSleepTolerance()
+    if value ~= nil then RNPhysics.world:setLinearSleepTolerance(value) else RNPhysics.world:setLinearSleepTolerance()
     end
 end
 
 --- sets the angular sleep tolerance
 function RNPhysics.setAngularSleepTolerance()
-    if value ~= nil then world:setAngularSleepTolerance(value) else world:setAngularSleepTolerance()
+    if value ~= nil then RNPhysics.world:setAngularSleepTolerance(value) else RNPhysics.world:setAngularSleepTolerance()
     end
 end
 
 --- gets the angular sleep tolerance
 function RNPhysics.getAngularSleepTolerance()
-    return world:getAngularSleepTolerance()
+    return RNPhysics.world:getAngularSleepTolerance()
 end
 
 --- gets the linear sleep tolerance
 function RNPhysics.getLinearSleepTolerance()
-    return world:getAngularSleepTolerance()
+    return RNPhysics.world:getAngularSleepTolerance()
 end
 
 --- gets the sleeping time
 function RNPhysics.getTimeToSleep()
-    return world:getAngularSleepTolerance()
+    return RNPhysics.world:getAngularSleepTolerance()
 end
 
 --- stops the physics simulation
 function RNPhysics.stop()
-    world:stop()
+    RNPhysics.world:stop()
 end
 
 --- sets the gravity
 -- @param xx float: x axis gravity
 -- @param yy float: y axis gravity
 function RNPhysics.setGravity(xx, yy)
-    world:setGravity(xx, yy)
+    RNPhysics.world:setGravity(xx, yy)
 end
 
 --- gets the gravity
 -- @return table: x and y
 function RNPhysics.getGravity()
-    local x, y = world:getGravity()
+    local x, y = RNPhysics.world:getGravity()
     return x, y
 end
 
@@ -96,7 +96,7 @@ end
 --- sets meters to units
 -- @param meters float: meters per box2d units
 function RNPhysics.setMeters(meters)
-    world:setUnitsToMeters(meters / 1000)
+    RNPhysics.world:setUnitsToMeters(meters / 1000)
     units = meters
 end
 
@@ -104,7 +104,7 @@ end
 -- @param velocity float
 -- @param position float
 function RNPhysics.setIterations(velocity, position)
-    world:setIterations(velocity, position)
+    RNPhysics.world:setIterations(velocity, position)
 end
 
 --- gets meters per units
@@ -116,13 +116,13 @@ end
 --- see box2d docs
 -- @param boolean boolean
 function RNPhysics.setAutoClearForces(boolean)
-    world:setAutoClearForces(boolean)
+    RNPhysics.world:setAutoClearForces(boolean)
 end
 
 --- see box2d docs
 -- @return value
 function RNPhysics.getAutoClearForces()
-    return world:getAutoClearForces()
+    return RNPhysics.world:getAutoClearForces()
 end
 
 --- gets the table list of the bodies in the physics world
@@ -209,11 +209,11 @@ function RNPhysics.createBodyFromImage(image, ...)
   the image. --]]
 
     --checks for body type
-    if (Type == "dynamic") then body = world:addBody(MOAIBox2DBody.DYNAMIC)
+    if (Type == "dynamic") then body = RNPhysics.world:addBody(MOAIBox2DBody.DYNAMIC)
     end
-    if (Type == "static") then body = world:addBody(MOAIBox2DBody.STATIC)
+    if (Type == "static") then body = RNPhysics.world:addBody(MOAIBox2DBody.STATIC)
     end
-    if (Type == "kinematic") then body = world:addBody(MOAIBox2DBody.KINEMATIC)
+    if (Type == "kinematic") then body = RNPhysics.world:addBody(MOAIBox2DBody.KINEMATIC)
     end
 
 
@@ -430,11 +430,11 @@ function RNPhysics.createBodyFromMapObject(mapObject, ...)
   the image. --]]
 
     --checks for body type
-    if (Type == "dynamic") then body = world:addBody(MOAIBox2DBody.DYNAMIC)
+    if (Type == "dynamic") then body = RNPhysics.world:addBody(MOAIBox2DBody.DYNAMIC)
     end
-    if (Type == "static") then body = world:addBody(MOAIBox2DBody.STATIC)
+    if (Type == "static") then body = RNPhysics.world:addBody(MOAIBox2DBody.STATIC)
     end
-    if (Type == "kinematic") then body = world:addBody(MOAIBox2DBody.KINEMATIC)
+    if (Type == "kinematic") then body = RNPhysics.world:addBody(MOAIBox2DBody.KINEMATIC)
     end
 
 
@@ -605,7 +605,7 @@ function RNPhysics.setDebugDraw(screen)
     --for i = 1, len, 1 do
     -- screen.sprites[i].visible = false;
     --end
-    layerfordebug:setBox2DWorld(world)
+    layerfordebug:setBox2DWorld(RNPhysics.world)
 end
 
 
@@ -781,7 +781,7 @@ function RNPhysics.createJoint(type, ...)
         bodyB = arg[2].physicObject
         anchorX = arg[3]
         anchorY = arg[4]
-        joint = world:addRevoluteJoint(bodyA.body, bodyB.body, anchorX, anchorY)
+        joint = RNPhysics.world:addRevoluteJoint(bodyA.body, bodyB.body, anchorX, anchorY)
     end
 
     --distance joint
@@ -799,7 +799,7 @@ function RNPhysics.createJoint(type, ...)
         end
         if (damping == nil) then damping = 0
         end
-        joint = world:addDistanceJoint(bodyA.body, bodyB.body, anchorA_X, anchorA_Y, anchorB_X, anchorB_Y, frequency, damping)
+        joint = RNPhysics.world:addDistanceJoint(bodyA.body, bodyB.body, anchorA_X, anchorA_Y, anchorB_X, anchorB_Y, frequency, damping)
     end
 
     --prismatic joint
@@ -811,7 +811,7 @@ function RNPhysics.createJoint(type, ...)
         anchorA_Y = arg[4]
         axisA = arg[5]
         axisB = arg[6]
-        joint = world:addPrismaticJoint(bodyA.body, bodyB.body, anchorA_X, anchorA_Y, axisA, axisB)
+        joint = RNPhysics.world:addPrismaticJoint(bodyA.body, bodyB.body, anchorA_X, anchorA_Y, axisA, axisB)
     end
 
     --friction joint
@@ -827,7 +827,7 @@ function RNPhysics.createJoint(type, ...)
         end
         if (maxTorque == nil) then maxTorque = 1000000
         end
-        joint = world:addFrictionJoint(bodyA.body, bodyB.body, anchorX, anchorY, maxForce, maxTorque)
+        joint = RNPhysics.world:addFrictionJoint(bodyA.body, bodyB.body, anchorX, anchorY, maxForce, maxTorque)
     end
 
     --weld joint
@@ -837,7 +837,7 @@ function RNPhysics.createJoint(type, ...)
         bodyB = arg[2].physicObject
         anchorX = arg[3]
         anchorY = arg[4]
-        joint = world:addWeldJoint(bodyA.body, bodyB.body, anchorX, anchorY)
+        joint = RNPhysics.world:addWeldJoint(bodyA.body, bodyB.body, anchorX, anchorY)
     end
 
     --wheel joint
@@ -849,7 +849,7 @@ function RNPhysics.createJoint(type, ...)
         anchorY = arg[4]
         axisX = arg[5]
         axisY = arg[6]
-        joint = world:addWheelJoint(bodyA.body, bodyB.body, anchorX, anchorY, axisX, axisY)
+        joint = RNPhysics.world:addWheelJoint(bodyA.body, bodyB.body, anchorX, anchorY, axisX, axisY)
     end
 
     --pulley joint
@@ -872,7 +872,7 @@ function RNPhysics.createJoint(type, ...)
         end
         if (maxLengthB == nil) then maxLengthB = 100
         end
-        joint = world:addPulleyJoint(bodyA.body, bodyB.body, groundAnchorA_X, groundAnchorA_Y, groundAnchorB_X, groundAnchorB_Y, anchorA_X, anchorA_Y, anchorB_X, anchorB_Y, ratio, maxLengthA, maxLengthB)
+        joint = RNPhysics.world:addPulleyJoint(bodyA.body, bodyB.body, groundAnchorA_X, groundAnchorA_Y, groundAnchorB_X, groundAnchorB_Y, anchorA_X, anchorA_Y, anchorB_X, anchorB_Y, ratio, maxLengthA, maxLengthB)
     end
 
     --gear joint
@@ -881,7 +881,7 @@ function RNPhysics.createJoint(type, ...)
         jointA = arg[1], joint
         jointB = arg[2].joint
         ratio = arg[3]
-        joint = world:addGearJoint(jointA, jointB, ratio)
+        joint = RNPhysics.world:addGearJoint(jointA, jointB, ratio)
     end
 
     --mouse joint
@@ -899,7 +899,7 @@ function RNPhysics.createJoint(type, ...)
         if (dampingRatio == nil) then dampingRatio = 0.2
         end
 
-        joint = world:addMouseJoint(bodyA.body, bodyB.body, world, targetX, targetY, maxForce, frequencyHz, dampingRatio)
+        joint = RNPhysics.world:addMouseJoint(bodyA.body, bodyB.body, RNPhysics.world, targetX, targetY, maxForce, frequencyHz, dampingRatio)
     end
 
 
@@ -932,7 +932,7 @@ function RNPhysics.createJoint(type, ...)
         end
         if (anchorBY == nil) then anchorBY = 0
         end
-        joint = world:addRopeJoint(bodyA.body, bodyB.body, maxLength, anchorAX, anchorAY, anchorBX, anchorBY)
+        joint = RNPhysics.world:addRopeJoint(bodyA.body, bodyB.body, maxLength, anchorAX, anchorAY, anchorBX, anchorBY)
         joint:destroy()
     end
 


### PR DESCRIPTION
This was motivated mostly by wanting to use the 'strict' module in my own rapanui-based game, but rapanui was triggering too many errors.

This changeset fixes the related errors that I could find. Some of these are strictly to appease the 'strict' module (e.g., initializing global variables to 'nil' at the global scope before they are accessed at local scopes). Many of these are genuine bugs though, mostly due to assigning to or reading from global variables where a local or module-scope variable was intended.
